### PR TITLE
Add palantir docker compose plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id 'com.palantir.docker-compose' version "0.25.0"
+}
+
 ext {
   interlokParentGradle = project.findProperty('interlokParentGradle') ?: 'https://raw.githubusercontent.com/adaptris-labs/interlok-build-parent/master/build.gradle'
   interlokVersion  = '3.10-SNAPSHOT'
@@ -14,4 +18,8 @@ allprojects {
 dependencies {
   interlokRuntime  group: "com.adaptris", name: "interlok-gcloud-pubsub", version: interlokVersion, changing: true
   interlokJavadocs group: "com.adaptris", name: "interlok-gcloud-pubsub", version: interlokVersion, changing: true, classifier: "javadoc", transitive: false
+}
+
+dockerCompose {
+  dockerComposeFile "docker-compose.yaml"
 }


### PR DESCRIPTION
## Motivation

```
gradle dockerComposeUp
gradle clean check assemble
(cd ./build/distribution && java -jar lib/interlok.boot.jar)
gradle dockerComposeDown
```

is what I want to do cos then 🥇  (mainly because I never seem to do `docker-compose up -d`

## Modification

Add palantir docker compose plugin to enable the requisite task

## Result

No requirement to use it but you can; shows up in `gradle tasks`

## Testing

```
$ gradle dockerComposeUp

> Task :dockerComposeUp
Creating network "gcloud-pubsub-interop_default" with the default driver
Creating gcloud-pubsub-interop_pubsub_1 ... done

BUILD SUCCESSFUL in 2s
1 actionable task: 1 executed
```

```
$ gradle dockerComposeDown

> Task :dockerComposeDown
Stopping gcloud-pubsub-interop_pubsub_1 ... done
Removing gcloud-pubsub-interop_pubsub_1 ... done
Removing network gcloud-pubsub-interop_default

BUILD SUCCESSFUL in 11s
1 actionable task: 1 executed
```

